### PR TITLE
Added default panning at location 0

### DIFF
--- a/wad.js
+++ b/wad.js
@@ -174,6 +174,8 @@ Check out http://www.voxengo.com/impulses/ for free impulse responses. **/
             this.panning = {
                 location : arg.panning
             }
+        } else {
+            this.panning = { location : 0 }
         }
 ////////////////////////////////
 


### PR DESCRIPTION
Hi Raphael,

I added a default panning with a zero location as default.

This is in case someone creates a wad without a panning and later call setPanning(X) to the wad instance.

Regards,
Allan
