### PR TITLE
fixed syntax in OSC example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ The Wad constructor supports many optional arguments to modify your sound, from 
     frequency : 600, // The frequency, in hertz, to which the filter is applied.
     q : 1, // Q-factor.  No one knows what this does. The default value is 1. Sensible values are from 0 to 10.
     env : { // Filter envelope.
-      frequency : 800, If this is set, filter frequency will slide from filter.frequency to filter.env.frequency when a note is triggered.
+      frequency : 800, // If this is set, filter frequency will slide from filter.frequency to filter.env.frequency when a note is triggered.
       attack : 0.5 // Time in seconds for the filter frequency to slide from filter.frequency to filter.env.frequency
+    }
   },
   reverb : {
     wet : 1, // Volume of the reverberations.


### PR DESCRIPTION
awesome library! I noticed the OSC example was missing a comment and a closing bracket.
