### PR TITLE
(Fix) Small syntax bug fix so file can be parsed

### DIFF
--- a/src/wad.js
+++ b/src/wad.js
@@ -1184,7 +1184,7 @@ var valueOrDefault = function(value, def) {
     var onSuccessCallback = function(midiAccess){
         // console.log('inputs: ', m.inputs)
         // Things you can do with the MIDIAccess object:
-        for ( var input of midiAccess.inputs.values() ) {
+        for ( var input in midiAccess.inputs.values() ) {
             console.log(input) 
         }
         Wad.midiInputs = []


### PR DESCRIPTION
`var input of` should be `var input in` on line 1187, otherwise, the file can't be parsed.

This fix should do the trick.

Thanks!