### PR TITLE
point bower "main" at the build wad.js file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Wad",
-  "main": "wad.js",
+  "main": "build/wad.js",
   "version": "1.7.1",
   "homepage": "https://github.com/rserota/wad",
   "authors": [


### PR DESCRIPTION
From the current bower.json:

    "main": "wad.js",

wad.js is inside `build/` though, so tools like wiredep and bowerRequirejs can't find it.  I suggest pointing it at `build/wad.js`.  I could be missing something though!  Thoughts?